### PR TITLE
PointData refinements

### DIFF
--- a/src/fields/regularization.jl
+++ b/src/fields/regularization.jl
@@ -224,11 +224,11 @@ end
 
 # ======  Regularization and interpolation operators of scalar types ======== #
 
-ftype = :(ScalarData{N,S})
+ftype = :(ScalarData{N,S,DT})
 for (ctype,dnx,dny,shiftx,shifty) in scalarlist
 
 # Regularization
-  @eval function (H::Regularize{N,F})(target::$ctype,source::$ftype) where {N,F,NX,NY,S,T}
+  @eval function (H::Regularize{N,F})(target::$ctype,source::$ftype) where {N,F,NX,NY,S,T,DT}
         radius = H.ddf_radius
         fill!(target,0.0)
         xmin = -radius+$shiftx; xmax = radius+$shiftx
@@ -245,7 +245,7 @@ for (ctype,dnx,dny,shiftx,shifty) in scalarlist
 
 
 # Interpolation
-  @eval function (H::Regularize{N,false})(target::$ftype,source::$ctype) where {N,NX,NY,S,T}
+  @eval function (H::Regularize{N,false})(target::$ftype,source::$ctype) where {N,NX,NY,S,T,DT}
         radius = H.ddf_radius
         fill!(target,0.0)
         xmin = -radius+$shiftx; xmax = radius+$shiftx
@@ -261,7 +261,7 @@ for (ctype,dnx,dny,shiftx,shifty) in scalarlist
   end
 
 # Interpolation with filtering
-  @eval function (H::Regularize{N,true})(target::$ftype,source::$ctype) where {N,NX,NY,S,T}
+  @eval function (H::Regularize{N,true})(target::$ftype,source::$ctype) where {N,NX,NY,S,T,DT}
         tmp = typeof(source)()
         radius = H.ddf_radius
         fill!(target,0.0)
@@ -289,7 +289,7 @@ for (ctype,dnx,dny,shiftx,shifty) in scalarlist
   # Construct regularization matrix
   @eval function RegularizationMatrix(H::Regularize{N,F},
     f::$ftype,
-    u::$ctype) where {N,F,NX,NY,S,T}
+    u::$ctype) where {N,F,NX,NY,S,T,DT}
 
     Hmat = spzeros(length(u),length(f))
     g = deepcopy(f)
@@ -312,7 +312,7 @@ for (ctype,dnx,dny,shiftx,shifty) in scalarlist
   # Construct interpolation matrix
   @eval function InterpolationMatrix(H::Regularize{N,false},
     u::$ctype,
-    f::$ftype) where {N,NX,NY,S,T}
+    f::$ftype) where {N,NX,NY,S,T,DT}
 
     Emat = spzeros(length(u),length(f))
     g = deepcopy(f)
@@ -332,7 +332,7 @@ for (ctype,dnx,dny,shiftx,shifty) in scalarlist
   # we defined above
   @eval function InterpolationMatrix(H::Regularize{N,true},
     u::$ctype,
-    f::$ftype) where {N,NX,NY,S,T}
+    f::$ftype) where {N,NX,NY,S,T,DT}
 
     Emat = spzeros(length(u),length(f))
     g = deepcopy(f)
@@ -353,25 +353,25 @@ end
 
 
 # ===== Regularization and interpolation operators of vector data to edges ===== #
-ftype = :(VectorData{N,S})
+ftype = :(VectorData{N,S,DT})
 for (ctype,dunx,duny,dvnx,dvny,shiftux,shiftuy,shiftvx,shiftvy) in vectorlist
 
 # Regularization
-  @eval function (H::Regularize{N,F})(target::$ctype,source::$ftype) where {N,F,NX,NY,S,T}
+  @eval function (H::Regularize{N,F})(target::$ctype,source::$ftype) where {N,F,NX,NY,S,T,DT}
         H(target.u,source.u)
         H(target.v,source.v)
         target
   end
 
 # Interpolation
-  @eval function (H::Regularize{N,F})(target::$ftype,source::$ctype) where {N,F,NX,NY,S,T}
+  @eval function (H::Regularize{N,F})(target::$ftype,source::$ctype) where {N,F,NX,NY,S,T,DT}
         H(target.u,source.u)
         H(target.v,source.v)
         target
   end
 
   # Construct regularization matrix
-  @eval function RegularizationMatrix(H::Regularize{N,F},src::$ftype,target::$ctype) where {N,F,NX,NY,S,T}
+  @eval function RegularizationMatrix(H::Regularize{N,F},src::$ftype,target::$ctype) where {N,F,NX,NY,S,T,DT}
 
     lenu = length(target.u)
     lenv = length(target.v)
@@ -391,7 +391,7 @@ for (ctype,dunx,duny,dvnx,dvny,shiftux,shiftuy,shiftvx,shiftvy) in vectorlist
   end
 
   # Construct interpolation matrix
-  @eval function InterpolationMatrix(H::Regularize{N,F},src::$ctype,target::$ftype) where {N,F,NX,NY,S,T}
+  @eval function InterpolationMatrix(H::Regularize{N,F},src::$ctype,target::$ftype) where {N,F,NX,NY,S,T,DT}
 
     # note that we store interpolation matrices in the same shape as regularization matrices
     lenu = length(src.u)
@@ -410,11 +410,11 @@ end
 # We do not use the scalar-wise operations here because there is double use of
 # the same ddf evaluation, so this saves us quite a bit of time.
 
-ftype = :(TensorData{N,S})
+ftype = :(TensorData{N,S,DT})
 for (ctype,dunx,duny,dvnx,dvny,shiftux,shiftuy,shiftvx,shiftvy) in tensorlist
 
 # Regularization
-  @eval function (H::Regularize{N,F})(target::$ctype,source::$ftype) where {N,F,NX,NY,S,T}
+  @eval function (H::Regularize{N,F})(target::$ctype,source::$ftype) where {N,F,NX,NY,S,T,DT}
         radius = H.ddf_radius
         fill!(target.dudx,0.0)
         fill!(target.dvdy,0.0)
@@ -454,7 +454,7 @@ for (ctype,dunx,duny,dvnx,dvny,shiftux,shiftuy,shiftvx,shiftvy) in tensorlist
   # end
 
 # Interpolation
-  @eval function (H::Regularize{N,false})(target::$ftype,source::$ctype) where {N,NX,NY,S,T}
+  @eval function (H::Regularize{N,false})(target::$ftype,source::$ctype) where {N,NX,NY,S,T,DT}
         radius = H.ddf_radius
         fill!(target.dudx,0.0)
         fill!(target.dvdy,0.0)
@@ -494,7 +494,7 @@ for (ctype,dunx,duny,dvnx,dvny,shiftux,shiftuy,shiftvx,shiftvy) in tensorlist
   # end
 
 # Interpolation with filtering -- need to speed up
-  @eval function (H::Regularize{N,true})(target::$ftype,source::$ctype) where {N,NX,NY,S,T}
+  @eval function (H::Regularize{N,true})(target::$ftype,source::$ctype) where {N,NX,NY,S,T,DT}
         tmp = typeof(source)()
         radius = H.ddf_radius
         fill!(target.dudx,0.0)
@@ -549,7 +549,7 @@ for (ctype,dunx,duny,dvnx,dvny,shiftux,shiftuy,shiftvx,shiftvy) in tensorlist
   end
 
   # Construct regularization matrix
-  @eval function RegularizationMatrix(H::Regularize{N,F},src::$ftype,target::$ctype) where {N,F,NX,NY,S,T}
+  @eval function RegularizationMatrix(H::Regularize{N,F},src::$ftype,target::$ctype) where {N,F,NX,NY,S,T,DT}
 
     # note that we only need to compute two distinct matrices, since there are
     # only two types of cell data in this tensor
@@ -582,7 +582,7 @@ for (ctype,dunx,duny,dvnx,dvny,shiftux,shiftuy,shiftvx,shiftvy) in tensorlist
   end
 
   # Construct interpolation matrix
-  @eval function InterpolationMatrix(H::Regularize{N,false},src::$ctype,target::$ftype) where {N,NX,NY,S,T}
+  @eval function InterpolationMatrix(H::Regularize{N,false},src::$ctype,target::$ftype) where {N,NX,NY,S,T,DT}
 
     # note that we store interpolation matrices in the same shape as regularization matrices
     #Emat = (spzeros(length(src.u),length(target.u)),spzeros(length(src.v),length(target.v)))
@@ -607,7 +607,7 @@ for (ctype,dunx,duny,dvnx,dvny,shiftux,shiftuy,shiftvx,shiftvy) in tensorlist
   end
 
   # Construct interpolation matrix with filtering
-  @eval function InterpolationMatrix(H::Regularize{N,true},src::$ctype,target::$ftype) where {N,NX,NY,S,T}
+  @eval function InterpolationMatrix(H::Regularize{N,true},src::$ctype,target::$ftype) where {N,NX,NY,S,T,DT}
 
     # note that we store interpolation matrices in the same shape as regularization matrices
     #Emat = (spzeros(length(src.u),length(target.u)),spzeros(length(src.v),length(target.v)))

--- a/src/systems/navier_stokes.jl
+++ b/src/systems/navier_stokes.jl
@@ -94,7 +94,7 @@ mutable struct NavierStokes{NX, NY, N, isstatic}  #<: System{Unconstrained}
 end
 
 function NavierStokes(Re, Δx, xlimits::Tuple{Real,Real},ylimits::Tuple{Real,Real}, Δt;
-                       U∞ = (0.0, 0.0), X̃ = VectorData{0,Float64}(),
+                       U∞ = (0.0, 0.0), X̃ = VectorData(0),
                        isstore = false,
                        isstatic = true,
                        isasymptotic = false,


### PR DESCRIPTION
Modified the constructors for PointData to fix some inconsistencies with creating instances.
* Allow instances of `ScalarData` from other instances, even if they are of different size and element type:
```
f = ScalarData(10)
a = zeros(Int,1000) 
@time g = typeof(f)(a);
   0.000010 seconds (6 allocations: 192 bytes)
```
* Fixed inconsistencies with other parts of code that use `PointData`
* Explicitly setting up all of the extensions of array function on `PointData` rather than using `@wraparray` macro