### PR TITLE
Remove GKS warnings

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Documenter, ViscousFlow
 
-ENV["GKSwstype"] = "nul"
+ENV["GKSwstype"] = "nul" # removes GKS warnings during plotting
 
 makedocs(
     sitename = "ViscousFlow.jl",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,7 @@
 using Documenter, ViscousFlow
 
+ENV["GKSwstype"] = "nul"
+
 makedocs(
     sitename = "ViscousFlow.jl",
     doctest = true,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ using Suppressor
 
 const GROUP = get(ENV, "GROUP", "All")
 
+ENV["GKSwstype"] = "nul" # removes GKS warnings during plotting
+
 notebookdir = "../examples"
 docdir = "../docs/src/manual"
 litdir = "./literate"


### PR DESCRIPTION
Sets the nul device as the default GR (Plots.jl backend) output in runtests.jl and docs/make.jl, which prevents the need for a display while plotting during testing and generating the documentation. This avoids the GKS warnings in the output.