### PR TITLE
Allow inviscid systems 

### DIFF
--- a/src/ViscousFlow.jl
+++ b/src/ViscousFlow.jl
@@ -27,10 +27,12 @@ function grid_spacing(phys_params)
     Δx = gridRe/get_Reynolds_number(phys_params)
 end
 
+grid_spacing(Δx::Float64) = Δx
 
 function get_Reynolds_number(phys_params)
-  haskey(phys_params,"Re") || error("No Reynolds number set")
-  return phys_params["Re"]
+  #haskey(phys_params,"Re") || error("No Reynolds number set")
+  #return phys_params["Re"]
+  return get(phys_params,"Re",Inf)
 end
 
 function default_timestep(sys)
@@ -145,7 +147,8 @@ function ImmersedLayers.prob_cache(prob::ViscousIncompressibleFlowProblem,
 
     # Construct a Lapacian outfitted with the viscosity
     Re = get_Reynolds_number(phys_params)
-    viscous_L = Laplacian(base_cache,gcurl_cache,1.0/Re)
+    over_Re = isinf(Re) ? 0.0 : 1.0/Re
+    viscous_L = Laplacian(base_cache,gcurl_cache,over_Re)
 
     # Create cache for the convective derivative
     cdcache = ConvectiveDerivativeCache(base_cache)
@@ -224,12 +227,10 @@ which are crucial for certain types of problems.
                   the `grid::PhysicalGrid` and `phys_params`, and returns the time step.
                   It defaults to the basic Fourier/CFL type function `default_timestep`
 """
-function viscousflow_system(args...;kwargs...)
-  prob = setup_problem(args...;kwargs...)
+function viscousflow_system(args...;phys_params=Dict(), kwargs...)
+  prob = setup_problem(args...;phys_params,kwargs...)
   return construct_system(prob)
 end
-
-
 
 #= ODE functions =#
 

--- a/src/ViscousFlow.jl
+++ b/src/ViscousFlow.jl
@@ -228,7 +228,7 @@ which are crucial for certain types of problems.
                   It defaults to the basic Fourier/CFL type function `default_timestep`
 """
 function viscousflow_system(args...;phys_params=Dict(), kwargs...)
-  prob = setup_problem(args...;phys_params,kwargs...)
+  prob = setup_problem(args...;phys_params=phys_params,kwargs...)
   return construct_system(prob)
 end
 

--- a/test/basicfields.jl
+++ b/test/basicfields.jl
@@ -27,3 +27,21 @@ using ImmersedLayers
   ψ = streamfunction(u,sys,t)
 
 end
+
+@testset "Inviscid system" begin
+
+  xlim = (-2.0,2.0)
+  ylim = (-2.0,2.0)
+  g = setup_grid(xlim,ylim,0.02)
+
+  sys = viscousflow_system(g)
+
+  σ = 0.2
+  x0 = 0.0
+  y0 = 0.0
+  A = 1
+  gauss = SpatialGaussian(σ,x0,y0,A)
+  u = init_sol(gauss,sys)
+
+
+end


### PR DESCRIPTION
Allow set up of inviscid systems as a special case, either by setting Re to infinity or just omitting it. Also allows omitting phys_params altogether. This is not really meant for using for advancing problems, since it will likely lead to spurious generation of vorticity via the no-slip condition. It is mostly meant for simple field calculations.