### PR TITLE
Added Q criterion function

### DIFF
--- a/test/basicfields.jl
+++ b/test/basicfields.jl
@@ -25,6 +25,7 @@ using ImmersedLayers
   vdv = convective_acceleration(u,sys,t)
   p = pressure(u,sys,t)
   ψ = streamfunction(u,sys,t)
+  Q = Qcrit(u,sys,t)    
 
 end
 
@@ -42,6 +43,7 @@ end
   A = 1
   gauss = SpatialGaussian(σ,x0,y0,A)
   u = init_sol(gauss,sys)
+
 
 
 end


### PR DESCRIPTION
This PR adds capability for computing the Q criterion. It treats this as a `@snapshotoutput`, so, e.g., you can call

`Qcrit(integrator)`