### PR TITLE
Faster cache construction

### DIFF
--- a/src/ode_operators.jl
+++ b/src/ode_operators.jl
@@ -40,7 +40,7 @@ function ImmersedLayers.prob_cache(prob::ViscousIncompressibleFlowProblem,
     # Construct a Lapacian outfitted with the viscosity
     Re = get_Reynolds_number(phys_params)
     over_Re = isinf(Re) ? 0.0 : 1.0/Re
-    viscous_L = Laplacian(base_cache,over_Re)
+    viscous_L = over_Re * base_cache.L
 
     # Create cache for the convective derivative
     cdcache = reference_body > 0 ? RotConvectiveDerivativeCache(base_cache) : ConvectiveDerivativeCache(base_cache)


### PR DESCRIPTION
Use the new CartesianGrids Laplacian function from the PR JuliaIBPM/CartesianGrids#58 with `base_cache.L` to avoid another `plan_laplacian`. Tests will probably fail because it depends on that PR.

Together with the PR JuliaIBPM/ImmersedLayers.jl#58 and the CG solver, this will result in faster moving-body simulations as shown with these screenshots of the example 6 notebook:

Before:

![Screenshot 2024-03-18 at 8 46 32 AM](https://github.com/JuliaIBPM/ViscousFlow.jl/assets/26737762/ec0d1ff6-a90e-457d-b47c-cb316ebf1f19)

After:

![Screenshot 2024-03-18 at 8 41 47 AM](https://github.com/JuliaIBPM/ViscousFlow.jl/assets/26737762/ea47ec68-cdcf-47f5-9859-b99638d62ce8)