### PR TITLE
Validate surface pressure calculations

### DIFF
--- a/src/fields.jl
+++ b/src/fields.jl
@@ -233,6 +233,24 @@ pressurejump!(out::VectorData{0},τ::VectorData{0},x,sys::ILMSystem,t) = out
 pressurejump(w::Nodes{Dual},τ::VectorData,x,sys::ILMSystem,t) = pressurejump!(zeros_surfacescalar(sys),τ,x,sys,t)
 @snapshotoutput pressurejump
 
+function pressplus(w::Nodes{Dual},τ::VectorData,x,sys::ILMSystem,t)
+    @unpack base_cache = sys
+    @unpack Ediv = base_cache
+    pbarb = Ediv*pressure(w,τ,x,sys,t)
+    dpb = pressurejump(w,τ,x,sys,t)
+    return pbarb + 0.5*dpb
+end
+@snapshotoutput pressplus
+
+function pressminus(w::Nodes{Dual},τ::VectorData,x,sys::ILMSystem,t)
+    @unpack base_cache = sys
+    @unpack Ediv = base_cache
+    pbarb = Ediv*pressure(w,τ,x,sys,t)
+    dpb = pressurejump(w,τ,x,sys,t)
+    return pbarb - 0.5*dpb
+end
+@snapshotoutput pressminus
+
 
 #= Integrated metrics =#
 

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -152,7 +152,7 @@ function convective_acceleration!(vdv::Edges{Primal},w::Nodes{Dual},x,sys::ILMSy
     @unpack extra_cache, base_cache = sys
     @unpack v_tmp, cdcache = extra_cache
     velocity!(v_tmp,w,x,sys,t)
-    convective_derivative!(vdv,v_tmp,base_cache,cdcache)
+    vdv .= convective_derivative(v_tmp,base_cache)
     return vdv
 end
 

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -233,23 +233,23 @@ pressurejump!(out::VectorData{0},τ::VectorData{0},x,sys::ILMSystem,t) = out
 pressurejump(w::Nodes{Dual},τ::VectorData,x,sys::ILMSystem,t) = pressurejump!(zeros_surfacescalar(sys),τ,x,sys,t)
 @snapshotoutput pressurejump
 
-function pressplus(w::Nodes{Dual},τ::VectorData,x,sys::ILMSystem,t)
+function pressureplus(w::Nodes{Dual},τ::VectorData,x,sys::ILMSystem,t)
     @unpack base_cache = sys
     @unpack Ediv = base_cache
     pbarb = Ediv*pressure(w,τ,x,sys,t)
     dpb = pressurejump(w,τ,x,sys,t)
     return pbarb + 0.5*dpb
 end
-@snapshotoutput pressplus
+@snapshotoutput pressureplus
 
-function pressminus(w::Nodes{Dual},τ::VectorData,x,sys::ILMSystem,t)
+function pressureminus(w::Nodes{Dual},τ::VectorData,x,sys::ILMSystem,t)
     @unpack base_cache = sys
     @unpack Ediv = base_cache
     pbarb = Ediv*pressure(w,τ,x,sys,t)
     dpb = pressurejump(w,τ,x,sys,t)
     return pbarb - 0.5*dpb
 end
-@snapshotoutput pressminus
+@snapshotoutput pressureminus
 
 
 #= Integrated metrics =#

--- a/src/ode_operators.jl
+++ b/src/ode_operators.jl
@@ -43,7 +43,8 @@ function ImmersedLayers.prob_cache(prob::ViscousIncompressibleFlowProblem,
     viscous_L = over_Re * base_cache.L
 
     # Create cache for the convective derivative
-    cdcache = reference_body > 0 ? RotConvectiveDerivativeCache(base_cache) : ConvectiveDerivativeCache(base_cache)
+    #cdcache = reference_body > 0 ? RotConvectiveDerivativeCache(base_cache) : ConvectiveDerivativeCache(base_cache)
+    cdcache = RotConvectiveDerivativeCache(base_cache)
 
     fcache = nothing
 
@@ -100,6 +101,7 @@ function viscousflow_velocity_ode_rhs!(dv,v,x,sys::ILMSystem,t)
     fill!(dv,0.0)
 
     # Calculate the convective derivative
+    fill!(dv_tmp,0.0)
     convective_term!(dv_tmp,v,x,t,base_cache,extra_cache,phys_params,motions,cdcache)
     dv .-= dv_tmp
 
@@ -109,6 +111,7 @@ function viscousflow_velocity_ode_rhs!(dv,v,x,sys::ILMSystem,t)
     #dv .-= dv_tmp
 
     # Apply forcing
+    fill!(dv_tmp,0.0)
     apply_forcing!(dv_tmp,v,x,t,fcache,sys)
     dv .+= dv_tmp
 


### PR DESCRIPTION
This PR adds some capability for calculating surface pressure, including the functions `pressureplus` and `pressureminus` for calculating surface pressure on either side of an immersed interface. It also switches the form of the convective term for inertial frame problems to the "rotational" form (as was already used in the noninertial cases). This has no effect on the flow predictions (since the w x v form and the v.grad v form are discretely equivalent modulo a term grad |v|^2/2 that gets absorbed into the pressure term, which then disappears when the curl is taken). However, it allows more compact domains for calculation of pressure, since the divergence of the convective term is a RHS forcing for the pressure Poisson equation, and the rotational form is only non-zero where there is vorticity.

The previous version of the code was predicting incorrect pressure fields (including on the surface of bodies) without unnecessarily large domains.

This PR version has been validated on the start-up flow past a cylinder at Re = 550, against results by Collins and Dennis (1973) and Koumoutsakos and Leonard (1995).